### PR TITLE
Reconcile typing

### DIFF
--- a/project/fed/utils/utils.py
+++ b/project/fed/utils/utils.py
@@ -286,7 +286,7 @@ def test_client(  # noqa: PLR0917
     parameters = parameters_to_ndarrays(initial_parameters)
     if test_all_clients or test_one_client:
         if test_one_client:
-            client = client_generator(0)
+            client = client_generator(str(0))
             _, *res_fit = client.fit(
                 parameters,
                 on_fit_config_fn(0) if on_fit_config_fn else {},
@@ -303,7 +303,7 @@ def test_client(  # noqa: PLR0917
             )
         else:
             for i in range(total_clients):
-                client = client_generator(i)
+                client = client_generator(str(i))
                 _, *res_fit = client.fit(
                     parameters,
                     on_fit_config_fn(i) if on_fit_config_fn else {},

--- a/project/main.py
+++ b/project/main.py
@@ -301,7 +301,9 @@ def main(cfg: DictConfig) -> None:
             # values for `num_cpus` and `num_gpus` iff
             # they're lower than 1.0.
             fl.simulation.start_simulation(
-                client_fn=client_generator,
+                # NOTE: mypy complains about the type of client_generator
+                # We must wait for reconciliation from Flower
+                client_fn=client_generator,  # type: ignore[arg-type]
                 num_clients=cfg.fed.num_total_clients,
                 client_resources={
                     "num_cpus": (

--- a/project/types/common.py
+++ b/project/types/common.py
@@ -33,7 +33,7 @@ FedDataloaderGen = Callable[[bool, dict], DataLoader]
 # Client generators require the client id only
 # necessary for ray instantiation
 # all changes in behaviour should be done via a closure
-ClientGen = Callable[[int | str], fl.client.NumPyClient]
+ClientGen = Callable[[str], fl.client.NumPyClient]
 
 TrainFunc = Callable[
     [nn.Module, DataLoader, dict, Path],

--- a/setup.sh
+++ b/setup.sh
@@ -50,7 +50,7 @@ fi
 
 current_version=$(pyenv local)
 
-if [ "$current_version" == "$VPYTHON_VERSION" ]; then
+if [ "$current_version" = "$VPYTHON_VERSION" ]; then
   echo "The local Python version is already set to $VPYTHON_VERSION"
 else
   pyenv local $VPYTHON_VERSION


### PR DESCRIPTION
The new Flower 1.6.0 is starting to reconcile client's types. There's still much to do, apparently. In the meantime, they force the client generator function to take a string. I've corrected it. I've also added a note where the client generator is used for the future.